### PR TITLE
Adding check for embedded browsers on MacOS 10.14

### DIFF
--- a/none.go
+++ b/none.go
@@ -2,9 +2,19 @@ package samesite
 
 import (
 	"net/http"
+	"regexp"
 
 	"github.com/avct/uasurfer"
 )
+
+var isMacEmbeddedBrowserRegexp = regexp.MustCompile(`^Mozilla\/[\.\d]+ \(Macintosh;.*Mac OS X [_\d]+\) AppleWebKit\/[\.\d]+ \(KHTML, like Gecko\)`)
+
+func isMacEmbeddedBrowser(userAgent string) bool {
+	if isMacEmbeddedBrowserRegexp.MatchString(userAgent) {
+		return true
+	}
+	return false
+}
 
 // Returns SameSite=None cookie attribute based on the list of incompatible browsers,
 // as described at https://www.chromium.org/updates/same-site/incompatible-clients.
@@ -23,7 +33,7 @@ func None(userAgent string) http.SameSite {
 	if ua.OS.Name == uasurfer.OSiOS && ua.OS.Version.Major == 12 {
 		return 0
 	}
-	if ua.OS.Name == uasurfer.OSMacOSX && ua.OS.Version.Major == 10 && ua.OS.Version.Minor == 14 && ua.Browser.Name == uasurfer.BrowserSafari {
+	if ua.OS.Name == uasurfer.OSMacOSX && ua.OS.Version.Major == 10 && ua.OS.Version.Minor == 14 && (ua.Browser.Name == uasurfer.BrowserSafari || isMacEmbeddedBrowser(userAgent)) {
 		return 0
 	}
 

--- a/none.go
+++ b/none.go
@@ -2,19 +2,9 @@ package samesite
 
 import (
 	"net/http"
-	"regexp"
 
 	"github.com/avct/uasurfer"
 )
-
-var isMacEmbeddedBrowserRegexp = regexp.MustCompile(`^Mozilla\/[\.\d]+ \(Macintosh;.*Mac OS X [_\d]+\) AppleWebKit\/[\.\d]+ \(KHTML, like Gecko\)`)
-
-func isMacEmbeddedBrowser(userAgent string) bool {
-	if isMacEmbeddedBrowserRegexp.MatchString(userAgent) {
-		return true
-	}
-	return false
-}
 
 // Returns SameSite=None cookie attribute based on the list of incompatible browsers,
 // as described at https://www.chromium.org/updates/same-site/incompatible-clients.
@@ -33,7 +23,7 @@ func None(userAgent string) http.SameSite {
 	if ua.OS.Name == uasurfer.OSiOS && ua.OS.Version.Major == 12 {
 		return 0
 	}
-	if ua.OS.Name == uasurfer.OSMacOSX && ua.OS.Version.Major == 10 && ua.OS.Version.Minor == 14 && (ua.Browser.Name == uasurfer.BrowserSafari || isMacEmbeddedBrowser(userAgent)) {
+	if ua.OS.Name == uasurfer.OSMacOSX && ua.OS.Version.Major == 10 && ua.OS.Version.Minor == 14 && (ua.Browser.Name == uasurfer.BrowserSafari || ua.Browser.Name == uasurfer.BrowserUnknown) {
 		return 0
 	}
 

--- a/none_test.go
+++ b/none_test.go
@@ -43,7 +43,8 @@ func TestCookieSetSameSiteNone(t *testing.T) {
 		{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0. 3165.0 Safari/537.36", false},                     // Chrome 62. Incompatible.
 		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36", false},              // Chrome 66. Incompatible.
 		{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36", true},                     // Chrome 69.
-		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36", true},                // Chrome 79.
+		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36", false},               // Embedded browser on MacOS 10.14. Incompatible.
+		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36", true},                // Chrome 79.
 	}
 
 	for _, tc := range tt {

--- a/none_test.go
+++ b/none_test.go
@@ -43,8 +43,10 @@ func TestCookieSetSameSiteNone(t *testing.T) {
 		{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0. 3165.0 Safari/537.36", false},                     // Chrome 62. Incompatible.
 		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36", false},              // Chrome 66. Incompatible.
 		{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36", true},                     // Chrome 69.
-		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36", false},               // Embedded browser on MacOS 10.14. Incompatible.
-		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36", true},                // Chrome 79.
+		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36", true},                // Chrome 79 on MacOS 10.14.
+		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36", true},                // Chrome 79 on MacOS 10.15.
+		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko)", false},                                                 // Embedded browser on MacOS 10.14. Incompatible.
+		{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko)", true},                                                 // Embedded browser on MacOS 10.11.
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
Adding a check for embedded browsers on MacOS 10.14. Regex is from https://www.chromium.org/updates/same-site/incompatible-clients